### PR TITLE
MODIFY: change review-related views using concrete view classes

### DIFF
--- a/watchlist_app/api/serializers.py
+++ b/watchlist_app/api/serializers.py
@@ -6,7 +6,8 @@ from watchlist_app.models import Review, WatchList, StreamPlatform
 class ReviewSerializer(serializers.ModelSerializer):
     class Meta:
         model  = Review
-        fields = "__all__"
+        exclude = ('watchlist', )
+        # fields = "__all__"
 
 
 class WatchListSerializer(serializers.ModelSerializer):

--- a/watchlist_app/api/urls.py
+++ b/watchlist_app/api/urls.py
@@ -1,12 +1,18 @@
 from django.urls import path, include
 # from watchlist_app.api.views import movie_list, movie_details
-from watchlist_app.api.views import StreamPlaformAV, StreamDetailAV, WatchListAV, WatchDetailAV, ReviewList, ReviewDetail
+from watchlist_app.api.views import StreamPlaformAV, StreamDetailAV, WatchListAV, WatchDetailAV, ReviewList, ReviewDetail, ReviewCreate
 
 urlpatterns = [
     path('list/', WatchListAV.as_view(), name='movie-list'),
     path('<int:pk>', WatchDetailAV.as_view(), name='movie-detail'),
     path('stream/', StreamPlaformAV.as_view(), name='stream'),
     path('stream/<int:pk>', StreamDetailAV.as_view(), name='stream-detail'),
-    path('stream/<int:pk>/review', StreamDetailAV.as_view(), name='stream-detail'),
+
+    # path('review/', ReviewList.as_view(), name='stream-detail'),
+    # path('review/<int:pk>', ReviewDetail.as_view(), name='review-detail'),
+
+    # strea/1/reivew 와 같이 사용하면, 마 stream 중에서 pk가 1에 해당하는 모든 review를 보여주는 것 같지만, 사실 이건 pk에 해당하는 watchlist의 review 전체를 보여준다.
+    path('stream/<int:pk>/review-create', ReviewCreate.as_view(), name='review-create'),
+    path('stream/<int:pk>/review', ReviewList.as_view(), name='review-list'),
     path('stream/review/<int:pk>', ReviewDetail.as_view(), name='review-detail'),
 ]

--- a/watchlist_app/api/views.py
+++ b/watchlist_app/api/views.py
@@ -1,31 +1,55 @@
 from rest_framework            import status
 from rest_framework.response   import Response
 from rest_framework.views      import APIView
-from rest_framework import generics
-from rest_framework import mixins
+from rest_framework            import generics
+# from rest_framework import mixins
 # from rest_framework.decorators import api_view
 
 from watchlist_app.models          import WatchList, StreamPlatform, Review
 from watchlist_app.api.serializers import ReviewSerializer, StreamPlatformSerializer, WatchListSerializer, StreamPlatform
 
 
-class ReviewDetail(mixins.RetrieveModelMixin, generics.GenericAPIView):
-    queryset = Review.objects.all()
+class ReviewCreate(generics.CreateAPIView):
     serializer_class = ReviewSerializer
 
-    def get(self, request, *args, **kwargs):
-        return self.retrieve(request, *args, **kwargs)
-    
+    def perform_create(self, serializer):
+        pk        = self.kwargs.get('pk')
+        watchlist = WatchList.objects.get(pk=pk)
+        serializer.save(watchlist=watchlist)
 
-class ReviewList(mixins.ListModelMixin, mixins.CreateModelMixin, generics.GenericAPIView):
-    queryset = Review.objects.all()
+
+class ReviewList(generics.ListAPIView):
+    # queryset         = Review.objects.all()
     serializer_class = ReviewSerializer
 
-    def get(self, request, *args, **kwargs):
-        return self.list(request, *args, **kwargs)
+    def get_queryset(self):
+        pk = self.kwargs['pk']
+        return Review.objects.filter(watchlist=pk)
+
+
+class ReviewDetail(generics.RetrieveUpdateDestroyAPIView):
+    queryset         = Review.objects.all()
+    serializer_class = ReviewSerializer
     
-    def post(self, request, *args, **kwargs):
-        return self.create(request, *args, **kwargs)
+
+# class ReviewDetail(mixins.RetrieveModelMixin, generics.GenericAPIView):
+#     queryset = Review.objects.all()
+#     serializer_class = ReviewSerializer
+
+#     def get(self, request, *args, **kwargs):
+#         return self.retrieve(request, *args, **kwargs)
+    
+
+# class ReviewList(mixins.ListModelMixin, mixins.CreateModelMixin, generics.GenericAPIView):
+#     queryset = Review.objects.all()
+#     serializer_class = ReviewSerializer
+
+#     def get(self, request, *args, **kwargs):
+#         return self.list(request, *args, **kwargs)
+    
+#     def post(self, request, *args, **kwargs):
+#         return self.create(request, *args, **kwargs)
+
 
 class StreamPlaformAV(APIView):
     def get(self, request):


### PR DESCRIPTION
- 기존의 review list view와 review detail view 수정
   - review list view, review detail view, review create view의 세 가지로 나눠 각 url 마다 하나의 역할만 하도록 설정
   - concrete view class 사용
   - get_queryset() 및 perform_create()를 사용하여 queryset과 create method override